### PR TITLE
PVT-434 - Do not block on FIFO when exiting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean deb
 
 CC = gcc
-CFLAGS = -Wall -O2
+CFLAGS = -Wall -Wextra -Werror -O2
 TARGET = bftee
 BUILD_DIR = build
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,6 @@ clean:
 deb: clean
 	dpkg-buildpackage -us -uc -Zgzip
 	# Repack with gzip compression for control.tar
-	dpkg-deb -R ../bftee_1.0-1_amd64.deb bftee_tmp
-	dpkg-deb -Zgzip -b bftee_tmp ../bftee_1.0-1_amd64.deb
+	dpkg-deb -R ../bftee_1.0-2_amd64.deb bftee_tmp
+	dpkg-deb -Zgzip -b bftee_tmp ../bftee_1.0-2_amd64.deb
 	rm -rf bftee_tmp

--- a/bftee.c
+++ b/bftee.c
@@ -38,8 +38,8 @@ int InitQueue(sQueue *, int);              /* initialises the Queue */
 void PushToQueue(sQueue *, sBuffer *, ssize_t);  /* pushes a buffer into Queue at the end */
 sBuffer *
 RetrieveFromQueue(sQueue *);       /* returns the first entry of the buffer and removes it or NULL is buffer is empty */
-sBuffer *PeakAtQueue(
-        sQueue *);             /* returns the first entry of the buffer but does not remove it. Returns NULL on an empty buffer */
+sBuffer *PeekAtQueue(
+        sQueue *queue);             /* returns the first entry of the buffer but does not remove it. Returns NULL on an empty buffer */
 void ShrinkInQueue(sQueue *queue,
                    ssize_t);    /* shrinks the first entry of the buffer by n-bytes. Buffer is removed if it is empty */
 void DelFromQueue(sQueue *queue);          /* removes the first entry of the queue */
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
         /* if the queue is empty (tmpBuffer gets set to NULL) the this does nothing - otherwise it tries to write
            the buffered data to the pipe. This continues until the Buffer is empty or the write fails.
            NOTE: bytes cannot be -1  (that would have failed just before) when the loop is entered. */
-        while((bytes != -1) && (tmpBuffer = PeakAtQueue(&queue)) != NULL) {
+        while((bytes != -1) && (tmpBuffer = PeekAtQueue(&queue)) != NULL) {
             /* write the oldest buffer to the pipe */
             bytes = write(writefd, tmpBuffer->data, tmpBuffer->bytes);
 
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
     /* once we are done with STDIN, try to flush the buffer to the named pipe */
     if(queue.active > 0) {
         sBuffer *tmpBuffer = NULL;
-        while((tmpBuffer = PeakAtQueue(&queue)) != NULL) {
+        while((tmpBuffer = PeekAtQueue(&queue)) != NULL) {
             bytes = write(writefd, tmpBuffer->data, tmpBuffer->bytes);
             /* Partial write, buffer is likely full */
             if(bytes != tmpBuffer->bytes) {
@@ -289,7 +289,7 @@ sBuffer *RetrieveFromQueue(sQueue *queue) {
 }
 
 /** return the oldest entry in the Queue or NULL if the Queue is empty. Does not remove the entry **/
-sBuffer *PeakAtQueue(sQueue *queue) {
+sBuffer *PeekAtQueue(sQueue *queue) {
     if(!queue->active) { return NULL; }
     return &(queue->data[queue->start]);
 }

--- a/bftee.c
+++ b/bftee.c
@@ -3,320 +3,346 @@
     (c) fabraxias@stackoverflow
     WTFPL Licence */
 
-    #include <stdio.h>
-    #include <stdlib.h>
-    #include <string.h>
-    #include <sys/types.h>
-    #include <sys/stat.h>
-    #include <fcntl.h>
-    #include <errno.h>
-    #include <signal.h>
-    #include <unistd.h>
+#include <stdio.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <signal.h>
+#include <unistd.h>
 
-    /* the number of sBuffers that are being held at a maximum */
-    #define BUFFER_SIZE 4096
-    #define BLOCK_SIZE 2048
+/* the number of sBuffers that are being held at a maximum */
+#define BUFFER_SIZE 4096
+#define BLOCK_SIZE 2048
 
-    typedef struct {
-      char data[BLOCK_SIZE];
-      int bytes;
-    } sBuffer;
+typedef struct {
+    char data[BLOCK_SIZE];
+    ssize_t bytes;
+} sBuffer;
 
-    typedef struct {
-      sBuffer *data;  /* array of buffers */
-      int bufferSize; /* number of buffer in data */
-      int start;      /* index of the current start buffer */
-      int end;        /* index of the current end buffer */
-      int active;     /* number of active buffer (currently in use) */
-      int maxUse;     /* maximum number of buffers ever used */
-      int drops;      /* number of discarded buffer due to overflow */
-      int sWrites;    /* number of buffer written to stdout */
-      int pWrites;    /* number of buffers written to pipe */
-    } sQueue;
+typedef struct {
+    sBuffer *data;  /* array of buffers */
+    int bufferSize; /* number of buffer in data */
+    int start;      /* index of the current start buffer */
+    int end;        /* index of the current end buffer */
+    int active;     /* number of active buffer (currently in use) */
+    int maxUse;     /* maximum number of buffers ever used */
+    int drops;      /* number of discarded buffer due to overflow */
+    int sWrites;    /* number of buffer written to stdout */
+    int pWrites;    /* number of buffers written to pipe */
+} sQueue;
 
-    void InitQueue(sQueue*, int);              /* initialized the Queue */
-    void PushToQueue(sQueue*, sBuffer*, int);  /* pushes a buffer into Queue at the end */
-    sBuffer *RetrieveFromQueue(sQueue*);       /* returns the first entry of the buffer and removes it or NULL is buffer is empty */
-    sBuffer *PeakAtQueue(sQueue*);             /* returns the first entry of the buffer but does not remove it. Returns NULL on an empty buffer */
-    void ShrinkInQueue(sQueue *queue, int);    /* shrinks the first entry of the buffer by n-bytes. Buffer is removed if it is empty */
-    void DelFromQueue(sQueue *queue);          /* removes the first entry of the queue */
+int InitQueue(sQueue *, int);              /* initialises the Queue */
+void PushToQueue(sQueue *, sBuffer *, ssize_t);  /* pushes a buffer into Queue at the end */
+sBuffer *
+RetrieveFromQueue(sQueue *);       /* returns the first entry of the buffer and removes it or NULL is buffer is empty */
+sBuffer *PeakAtQueue(
+        sQueue *);             /* returns the first entry of the buffer but does not remove it. Returns NULL on an empty buffer */
+void ShrinkInQueue(sQueue *queue,
+                   ssize_t);    /* shrinks the first entry of the buffer by n-bytes. Buffer is removed if it is empty */
+void DelFromQueue(sQueue *queue);          /* removes the first entry of the queue */
+void ReleaseQueue(sQueue *queue);
 
-    static void sigUSR1(int);                  /* signal handled for SUGUSR1 - used for stats output to stderr */
-    static void sigINT(int);                   /* signla handler for SIGKILL/SIGTERM - allows for a graceful stop ? */
+static void
+sigUSR1(__attribute__((unused)) int);                  /* signal handled for SUGUSR1 - used for stats output to stderr */
+static void sigINT(int);                   /* signla handler for SIGKILL/SIGTERM - allows for a graceful stop ? */
 
-    sQueue queue;                              /* Buffer storing the overflow */
-    volatile int quit;                         /* for quiting the main loop */
+sQueue queue;                              /* Buffer storing the overflow */
+volatile int quit;                         /* for quiting the main loop */
 
-    int main(int argc, char *argv[])
-    {   
-        int readfd, writefd;
-        struct stat status;
-        char *fifonam;
-        sBuffer buffer;
-        ssize_t bytes;
-        int bufferSize = BUFFER_SIZE;
+int main(int argc, char *argv[]) {
+    int readfd, writefd;
+    struct stat status;
+    char *fifonam;
+    sBuffer buffer;
+    ssize_t bytes;
+    int bufferSize = BUFFER_SIZE;
 
-        signal(SIGPIPE, SIG_IGN);
-        signal(SIGUSR1, sigUSR1);
-        signal(SIGTERM, sigINT);
-        signal(SIGINT,  sigINT);
+    signal(SIGPIPE, SIG_IGN);
+    signal(SIGUSR1, sigUSR1);
+    signal(SIGTERM, sigINT);
+    signal(SIGINT, sigINT);
 
-        /** Handle commandline args and open the pipe for non blocking writing **/
+    /** Handle commandline args and open the pipe for non blocking writing **/
 
-        /* Check for help options */
-        if (argc == 2 && (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0)) {
-            printf("bftee - buffered, non-blocking tee for named pipes\n\n");
-            printf("Usage:\n");
-            printf("  someprog 2>&1 | %s FIFO [BufferSize]\n\n", argv[0]);
-            printf("Arguments:\n");
-            printf("  FIFO        Path to a named pipe (required)\n");
-            printf("  BufferSize  Internal buffer size when write to FIFO fails (default: %d)\n\n", BUFFER_SIZE);
-            printf("Signals:\n");
-            printf("  SIGUSR1     Print buffer statistics to stderr\n");
-            printf("  SIGTERM     Graceful shutdown with buffer flush\n");
-            printf("  SIGINT      Graceful shutdown (first signal), force exit (second signal)\n\n");
-            printf("Examples:\n");
-            printf("  mkfifo /tmp/myfifo\n");
-            printf("  ./myprogram 2>&1 | %s /tmp/myfifo\n", argv[0]);
-            printf("  ./myprogram 2>&1 | %s /tmp/myfifo 8192\n\n", argv[0]);
-            printf("See manual page or documentation for more details.\n");
-            exit(EXIT_SUCCESS);
-        }
+    /* Check for help options */
+    if(argc == 2 && (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0)) {
+        printf("bftee - buffered, non-blocking tee for named pipes\n\n");
+        printf("Usage:\n");
+        printf("  someprog 2>&1 | %s FIFO [BufferSize]\n\n", argv[0]);
+        printf("Arguments:\n");
+        printf("  FIFO        Path to a named pipe (required)\n");
+        printf("  BufferSize  Internal buffer size when write to FIFO fails (default: %d)\n\n", BUFFER_SIZE);
+        printf("Signals:\n");
+        printf("  SIGUSR1     Print buffer statistics to stderr\n");
+        printf("  SIGTERM     Graceful shutdown with buffer flush\n");
+        printf("  SIGINT      Graceful shutdown (first signal), force exit (second signal)\n\n");
+        printf("Examples:\n");
+        printf("  mkfifo /tmp/myfifo\n");
+        printf("  ./myprogram 2>&1 | %s /tmp/myfifo\n", argv[0]);
+        printf("  ./myprogram 2>&1 | %s /tmp/myfifo 8192\n\n", argv[0]);
+        printf("See manual page or documentation for more details.\n");
+        exit(EXIT_SUCCESS);
+    }
 
-        if(argc < 2 || argc > 3)
-        {   
-            printf("Usage:\n someprog 2>&1 | %s FIFO [BufferSize]\n"
-                   "FIFO - path to a named pipe, required argument\n"
-                   "BufferSize - temporary Internal buffer size in case write to FIFO fails\n"
-                   "Use --help or -h for detailed help\n", argv[0]);
+    if(argc < 2 || argc > 3) {
+        printf("Usage:\n someprog 2>&1 | %s FIFO [BufferSize]\n"
+               "FIFO - path to a named pipe, required argument\n"
+               "BufferSize - temporary Internal buffer size in case write to FIFO fails\n"
+               "Use --help or -h for detailed help\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    fifonam = argv[1];
+    if(argc == 3) {
+        char* strtolErr;
+        long tmpBufferSize = strtol(argv[2], &strtolErr, 10);
+        if(strtolErr == argv[2] || *strtolErr != '\0' || tmpBufferSize < 0 || tmpBufferSize > INT_MAX) {
+            fprintf(stderr, "bftee: Invalid buffer size given: %s\n", argv[2]);
             exit(EXIT_FAILURE);
         }
-
-        fifonam = argv[1];
-        if (argc == 3) {
-          bufferSize = atoi(argv[2]);
-          if (bufferSize == 0) bufferSize = BUFFER_SIZE;
+        else if(tmpBufferSize == 0) {
+            bufferSize = BUFFER_SIZE;
         }
-
-        readfd = open(fifonam, O_RDONLY | O_NONBLOCK);
-        if(-1==readfd)
-        {   
-            perror("bftee: readfd: open()");
-            exit(EXIT_FAILURE);
+        else {
+            bufferSize = (int) tmpBufferSize;
         }
+    }
 
-        if(-1==fstat(readfd, &status))
-        {
-            perror("bftee: fstat");
-            close(readfd);
-            exit(EXIT_FAILURE);
-        }
+    if(!InitQueue(&queue, bufferSize)) {
+        perror("bftee: failed to allocate queue");
+        exit(EXIT_FAILURE);
+    }
 
-        if(!S_ISFIFO(status.st_mode))
-        {
-            printf("bftee: %s in not a fifo!\n", fifonam);
-            close(readfd);
-            exit(EXIT_FAILURE);
-        }
+    readfd = open(fifonam, O_RDONLY | O_NONBLOCK);
+    if(-1 == readfd) {
+        perror("bftee: readfd: open()");
+        exit(EXIT_FAILURE);
+    }
 
-        writefd = open(fifonam, O_WRONLY | O_NONBLOCK);
-        if(-1==writefd)
-        {
-            perror("bftee: writefd: open()");
-            close(readfd);
-            exit(EXIT_FAILURE);
-        }
-
+    if(-1 == fstat(readfd, &status)) {
+        perror("bftee: fstat");
         close(readfd);
+        exit(EXIT_FAILURE);
+    }
 
+    if(!S_ISFIFO(status.st_mode)) {
+        printf("bftee: %s in not a fifo!\n", fifonam);
+        close(readfd);
+        exit(EXIT_FAILURE);
+    }
 
-        InitQueue(&queue, bufferSize);
-        quit = 0;
+    writefd = open(fifonam, O_WRONLY | O_NONBLOCK);
+    if(-1 == writefd) {
+        perror("bftee: writefd: open()");
+        close(readfd);
+        exit(EXIT_FAILURE);
+    }
 
-        while(!quit)
-        {
-            /* read from STDIN */
-            bytes = read(STDIN_FILENO, buffer.data, sizeof(buffer.data));
+    close(readfd);
 
-            /* if read failed due to interrupt, then retry, otherwise STDIN has closed and we should stop reading */
-            if (bytes < 0 && errno == EINTR) continue;
-            if (bytes <= 0) break;
+    quit = 0;
+    while(!quit) {
+        /* read from STDIN */
+        bytes = read(STDIN_FILENO, buffer.data, sizeof(buffer.data));
 
-            /* save the number if read bytes in the current buffer to be processed */
-            buffer.bytes = bytes;
+        /* if read failed due to interrupt, then retry, otherwise STDIN has closed and we should stop reading */
+        if(bytes < 0 && errno == EINTR) continue;
+        if(bytes <= 0) break;
 
-            /* this is a blocking write. As long as buffer is smaller than 4096 Bytes, the write is atomic to a pipe in Linux
-               thus, this cannot be interrupted. however, to be save this should handle the error cases of partial or interrupted write none the less. */
-            bytes = write(STDOUT_FILENO, buffer.data, buffer.bytes);
-            queue.sWrites++;
+        /* save the number if read bytes in the current buffer to be processed */
+        buffer.bytes = bytes;
 
-            if(-1==bytes) {
-                perror("ftee: writing to stdout");
+        /* this is a blocking write. As long as buffer is smaller than 4096 Bytes, the write is atomic to a pipe in Linux
+           thus, this cannot be interrupted. however, to be save this should handle the error cases of partial or interrupted write none the less. */
+        bytes = write(STDOUT_FILENO, buffer.data, buffer.bytes);
+        queue.sWrites++;
+
+        if(-1 == bytes) {
+            perror("ftee: writing to stdout");
+            break;
+        }
+
+        sBuffer *tmpBuffer = NULL;
+
+        /* if the queue is empty (tmpBuffer gets set to NULL) the this does nothing - otherwise it tries to write
+           the buffered data to the pipe. This continues until the Buffer is empty or the write fails.
+           NOTE: bytes cannot be -1  (that would have failed just before) when the loop is entered. */
+        while((bytes != -1) && (tmpBuffer = PeakAtQueue(&queue)) != NULL) {
+            /* write the oldest buffer to the pipe */
+            bytes = write(writefd, tmpBuffer->data, tmpBuffer->bytes);
+
+            /* the  written bytes are equal to the buffer size, the write is successful - remove the buffer and continue */
+            if(bytes == tmpBuffer->bytes) {
+                DelFromQueue(&queue);
+                queue.pWrites++;
+            }
+            else if(bytes > 0) {
+                /* on a positive bytes value there was a partial write. we shrink the current buffer
+                   and handle this as a write failure */
+                ShrinkInQueue(&queue, bytes);
+                bytes = -1;
+            }
+        }
+        /* There are several cases here:
+           1.) The Queue is empty -> bytes is still set from the write to STDOUT. in this case, we try to write the read data directly to the pipe
+           2.) The Queue was not empty but is now -> bytes is set from the last write (which was successful) and is bigger 0. also try to write the data
+           3.) The Queue was not empty and still is not -> there was a write error before (even partial), and bytes is -1. Thus this line is skipped. */
+        if(bytes != -1) bytes = write(writefd, buffer.data, buffer.bytes);
+
+        /* again, there are several cases what can happen here
+           1.) the write before was successful -> in this case bytes is equal to buffer.bytes and nothing happens
+           2.) the write just before is partial or failed all together - bytes is either -1 or smaller than buffer.bytes -> add the remaining data to the queue
+           3.) the write before did not happen as the buffer flush already had an error. In this case bytes is -1 -> add the remaining data to the queue */
+        if(bytes != buffer.bytes)
+            PushToQueue(&queue, &buffer, bytes);
+        else
+            queue.pWrites++;
+    }
+
+    /* once we are done with STDIN, try to flush the buffer to the named pipe */
+    if(queue.active > 0) {
+        sBuffer *tmpBuffer = NULL;
+        while((tmpBuffer = PeakAtQueue(&queue)) != NULL) {
+            bytes = write(writefd, tmpBuffer->data, tmpBuffer->bytes);
+            /* Partial write, buffer is likely full */
+            if(bytes != tmpBuffer->bytes) {
+                // If our write fails or is partial breakout
                 break;
             }
-
-            sBuffer *tmpBuffer = NULL;
-
-            /* if the queue is empty (tmpBuffer gets set to NULL) the this does nothing - otherwise it tries to write
-               the buffered data to the pipe. This continues until the Buffer is empty or the write fails.
-               NOTE: bytes cannot be -1  (that would have failed just before) when the loop is entered. */
-            while ((bytes != -1) && (tmpBuffer = PeakAtQueue(&queue)) != NULL) {
-               /* write the oldest buffer to the pipe */
-               bytes = write(writefd, tmpBuffer->data, tmpBuffer->bytes);
-
-               /* the  written bytes are equal to the buffer size, the write is successful - remove the buffer and continue */
-               if (bytes == tmpBuffer->bytes) {
-                 DelFromQueue(&queue);
-                 queue.pWrites++;
-               } else if (bytes > 0) {
-                 /* on a positive bytes value there was a partial write. we shrink the current buffer
-                    and handle this as a write failure */
-                 ShrinkInQueue(&queue, bytes);
-                 bytes = -1;
-               }
+            else {
+                DelFromQueue(&queue);
             }
-            /* There are several cases here:
-               1.) The Queue is empty -> bytes is still set from the write to STDOUT. in this case, we try to write the read data directly to the pipe
-               2.) The Queue was not empty but is now -> bytes is set from the last write (which was successful) and is bigger 0. also try to write the data
-               3.) The Queue was not empty and still is not -> there was a write error before (even partial), and bytes is -1. Thus this line is skipped. */
-            if (bytes != -1) bytes = write(writefd, buffer.data, buffer.bytes);
-
-            /* again, there are several cases what can happen here
-               1.) the write before was successful -> in this case bytes is equal to buffer.bytes and nothing happens
-               2.) the write just before is partial or failed all together - bytes is either -1 or smaller than buffer.bytes -> add the remaining data to the queue
-               3.) the write before did not happen as the buffer flush already had an error. In this case bytes is -1 -> add the remaining data to the queue */
-            if (bytes != buffer.bytes)
-              PushToQueue(&queue, &buffer, bytes);
-            else 
-              queue.pWrites++;
         }
+    }
 
-        /* once we are done with STDIN, try to flush the buffer to the named pipe */
-        if (queue.active > 0) {
-           /* set output buffer to blocking mode to ensure all buffered data is written */
-           int saved_flags = fcntl(writefd, F_GETFL);
-           int new_flags = saved_flags & ~O_NONBLOCK;
-           fcntl(writefd, F_SETFL, new_flags);
+    /* Ensure the queue is properly released */
+    ReleaseQueue(&queue);
 
-           sBuffer *tmpBuffer = NULL;
-           /* TODO: this does not handle partial writes yet */
-           while ((tmpBuffer = PeakAtQueue(&queue)) != NULL) {
-             int bytes = write(writefd, tmpBuffer->data, tmpBuffer->bytes);
-             if (bytes != -1) DelFromQueue(&queue);
-           }
-        }
+    close(writefd);
+    return 0;
+}
 
-        close(writefd);
+
+/** init a given Queue **/
+int InitQueue(sQueue *queue, int bufferSize) {
+    queue->data = calloc(bufferSize, sizeof(sBuffer));
+    queue->bufferSize = bufferSize;
+    queue->start = 0;
+    queue->end = 0;
+    queue->active = 0;
+    queue->maxUse = 0;
+    queue->drops = 0;
+    queue->sWrites = 0;
+    queue->pWrites = 0;
+
+    /* Check whether calloc was successful or not, and let the caller know. */
+    if(queue->data == NULL) {
         return 0;
     }
+    else {
+        return 1;
+    }
+}
 
+/** push a buffer into the Queue**/
+void PushToQueue(sQueue *queue, sBuffer *p, ssize_t offset) {
 
-    /** init a given Queue **/
-    void InitQueue (sQueue *queue, int bufferSize) {
-      queue->data = calloc(bufferSize, sizeof(sBuffer));
-      queue->bufferSize = bufferSize;
-      queue->start = 0;
-      queue->end = 0;
-      queue->active = 0;
-      queue->maxUse = 0;
-      queue->drops = 0;
-      queue->sWrites = 0;
-      queue->pWrites = 0;
+    if(offset < 0)
+        offset = 0;      /* offset cannot be smaller than 0 - if that is the case, we were given an error code. Set it to 0 instead */
+    if(offset == p->bytes) return;  /* in this case there are 0 bytes to add to the queue. Nothing to write */
+
+    /* this should never happen - offset cannot be bigger than the buffer itself. Panic action */
+    if(offset > p->bytes) {
+        perror("got more bytes to buffer than we read\n");
+        exit(EXIT_FAILURE);
     }
 
-    /** push a buffer into the Queue**/
-    void PushToQueue(sQueue *queue, sBuffer *p, int offset)
-    {
+    /* copy the data from the buffer into the queue and remember its size */
+    memcpy(queue->data[queue->end].data, p->data + offset, p->bytes - offset);
+    queue->data[queue->end].bytes = p->bytes - offset;
 
-        if (offset < 0) offset = 0;      /* offset cannot be smaller than 0 - if that is the case, we were given an error code. Set it to 0 instead */
-        if (offset == p->bytes) return;  /* in this case there are 0 bytes to add to the queue. Nothing to write */
+    /* move the buffer forward */
+    queue->end = (queue->end + 1) % queue->bufferSize;
 
-        /* this should never happen - offset cannot be bigger than the buffer itself. Panic action */
-        if (offset > p->bytes) {perror("got more bytes to buffer than we read\n"); exit(EXIT_FAILURE);}
-
-        /* debug output on a partial write. TODO: remove this line
-           if (offset > 0 ) fprintf(stderr, "partial write to buffer\n"); */
-
-        /* copy the data from the buffer into the queue and remember its size */
-        memcpy(queue->data[queue->end].data, p->data + offset , p->bytes-offset);
-        queue->data[queue->end].bytes = p->bytes - offset;
-
-        /* move the buffer forward */
-        queue->end = (queue->end + 1) % queue->bufferSize;
-
-        /* there is still space in the buffer */
-        if (queue->active < queue->bufferSize)
-        {
-            queue->active++;
-            if (queue->active > queue->maxUse) queue->maxUse = queue->active;
-        } else {
-            /* Overwriting the oldest. Move start to next-oldest */
-            queue->start = (queue->start + 1) % queue->bufferSize;
-            queue->drops++;
-        }
+    /* there is still space in the buffer */
+    if(queue->active < queue->bufferSize) {
+        queue->active++;
+        if(queue->active > queue->maxUse) queue->maxUse = queue->active;
     }
-
-    /** return the oldest entry in the Queue and remove it or return NULL in case the Queue is empty **/
-    sBuffer *RetrieveFromQueue(sQueue *queue)
-    {
-        if (!queue->active) { return NULL; }
-
+    else {
+        /* Overwriting the oldest. Move start to next-oldest */
         queue->start = (queue->start + 1) % queue->bufferSize;
-        queue->active--;
-        return &(queue->data[queue->start]);
+        queue->drops++;
     }
+}
 
-    /** return the oldest entry in the Queue or NULL if the Queue is empty. Does not remove the entry **/
-    sBuffer *PeakAtQueue(sQueue *queue)
-    {
-        if (!queue->active) { return NULL; }
-        return &(queue->data[queue->start]);
-    }
+/** return the oldest entry in the Queue and remove it or return NULL in case the Queue is empty **/
+sBuffer *RetrieveFromQueue(sQueue *queue) {
+    if(!queue->active) { return NULL; }
 
-    /*** Shrinks the oldest entry i the Queue by bytes. Removes the entry if buffer of the oldest entry runs empty*/
-    void ShrinkInQueue(sQueue *queue, int bytes) {
+    queue->start = (queue->start + 1) % queue->bufferSize;
+    queue->active--;
+    return &(queue->data[queue->start]);
+}
 
-      /* cannot remove negative amount of bytes - this is an error case. Ignore it */
-      if (bytes <= 0) return;
+/** return the oldest entry in the Queue or NULL if the Queue is empty. Does not remove the entry **/
+sBuffer *PeakAtQueue(sQueue *queue) {
+    if(!queue->active) { return NULL; }
+    return &(queue->data[queue->start]);
+}
 
-      /* remove the entry if the offset is equal to the buffer size */
-      if (queue->data[queue->start].bytes == bytes) {
+/*** Shrinks the oldest entry i the Queue by bytes. Removes the entry if buffer of the oldest entry runs empty*/
+void ShrinkInQueue(sQueue *queue, ssize_t bytes) {
+
+    /* cannot remove negative amount of bytes - this is an error case. Ignore it */
+    if(bytes <= 0) return;
+
+    /* remove the entry if the offset is equal to the buffer size */
+    if(queue->data[queue->start].bytes == bytes) {
         DelFromQueue(queue);
         return;
-      };
+    };
 
-      /* this is a partial delete */
-      if (queue->data[queue->start].bytes > bytes) {
+    /* this is a partial delete */
+    if(queue->data[queue->start].bytes > bytes) {
         /* shift the memory by the offset */
-        memmove(queue->data[queue->start].data, queue->data[queue->start].data + bytes, queue->data[queue->start].bytes - bytes);
+        memmove(queue->data[queue->start].data, queue->data[queue->start].data + bytes,
+                queue->data[queue->start].bytes - bytes);
         queue->data[queue->start].bytes = queue->data[queue->start].bytes - bytes;
         return;
-      }
+    }
 
-      /* panic is the are to remove more than we have the buffer */
-      if (queue->data[queue->start].bytes < bytes) {
+    /* panic is the are to remove more than we have the buffer */
+    if(queue->data[queue->start].bytes < bytes) {
         perror("we wrote more than we had - this should never happen\n");
         exit(EXIT_FAILURE);
-        return;
-      }
     }
+}
 
-    /** delete the oldest entry from the queue. Do nothing if the Queue is empty **/
-    void DelFromQueue(sQueue *queue)
-    {
-        if (queue->active > 0) {
-          queue->start = (queue->start + 1) % queue->bufferSize;
-          queue->active--;
-        }
+/** delete the oldest entry from the queue. Do nothing if the Queue is empty **/
+void DelFromQueue(sQueue *queue) {
+    if(queue->active > 0) {
+        queue->start = (queue->start + 1) % queue->bufferSize;
+        queue->active--;
     }
+}
 
-    /** Stats output on SIGUSR1 **/
-    static void sigUSR1(int signo) {
-      fprintf(stderr, "Buffer use: %i (%i/%i), STDOUT: %i PIPE: %i:%i\n", queue.active, queue.maxUse, queue.bufferSize, queue.sWrites, queue.pWrites, queue.drops);
-    }
+/** Release resources from the queue **/
+void ReleaseQueue(sQueue *queue) {
+    free(queue->data);
+}
 
-    /** handle signal for terminating **/
-    static void sigINT(int signo) {
-      quit++;
-      if (quit > 1) exit(EXIT_FAILURE);
-    }
+/** Stats output on SIGUSR1 **/
+static void sigUSR1(__attribute__((unused)) int signo) {
+    fprintf(stderr, "Buffer use: %i (%i/%i), STDOUT: %i PIPE: %i:%i\n", queue.active, queue.maxUse, queue.bufferSize,
+            queue.sWrites, queue.pWrites, queue.drops);
+}
+
+/** handle signal for terminating **/
+static void sigINT(__attribute__((unused)) int signo) {
+    quit++;
+    if(quit > 1) exit(EXIT_FAILURE);
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+bftee (1.0-2) unstable; urgency=low
+
+  * Non-blocking is now used when attempting to empty the queue so that a reader is
+    not required to end the `bftee` process.
+  * Code quality improvements:
+    - Fixed compiler warnings with __attribute__((unused)) for signal handlers
+    - Improved type safety using ssize_t for byte counts
+    - Added proper memory cleanup with ReleaseQueue() function
+    - Replaced atoi() with strtol() for safer integer conversion
+      - Included additional checks for long to integer conversion
+    - Consistent code formatting and indentation
+    - calloc() is now checked for NULL return.
+
+ -- Andrew Walker <andrew.walker@sohonet.com>  Tue, 12 Aug 2025 12:00:00 +0000
+
 bftee (1.0-1) unstable; urgency=low
 
   * Initial release.


### PR DESCRIPTION
- Stopped using blocking mode when exiting the program. This means that `bftee` cannot be blocked from properly exiting if there is not a reader on the FIFO.
- Formatted the code.
- Added some compiler warnings for unused attributes.
- Changed the build to treat all warnings as errors.
- Changed the input handling for the buffer conversion from the command line to have error handling.
- Calloc call is now checked for a NULL return and properly handled.
- Improved type safety by switching out instances of `int` with `ssize_t` when interacting with `read` or `write`.
- Removed unnecessary TODO's.